### PR TITLE
open source dashboard: rename default branch option and set hermit's default branch

### DIFF
--- a/projects-dashboard/src/content/config.ts
+++ b/projects-dashboard/src/content/config.ts
@@ -3,7 +3,7 @@ import { defineCollection, z } from "astro:content";
 const repoSchema = z.object({
   owner: z.string(),
   name: z.string(),
-  mainBranch: z.string().optional(),
+  defaultBranch: z.string().optional(),
   subPath: z.string().optional(),
 });
 

--- a/projects-dashboard/src/content/project/cashapp_AccessibilitySnapshot.md
+++ b/projects-dashboard/src/content/project/cashapp_AccessibilitySnapshot.md
@@ -2,7 +2,7 @@
 repo:
   owner: "cashapp"
   name: "AccessibilitySnapshot"
-  mainBranch: "master"
+  defaultBranch: "master"
 title: "AccessibilitySnapshot"
 description: "Easy regression testing for iOS accessibility"
 branding: "cashapp"

--- a/projects-dashboard/src/content/project/cashapp_hermit.md
+++ b/projects-dashboard/src/content/project/cashapp_hermit.md
@@ -2,6 +2,7 @@
 repo:
   owner: cashapp
   name: hermit
+  defaultBranch: "master"
 title: hermit
 description: Hermit manages isolated, self-bootstrapping sets of tools in software projects.
 branding: cashapp

--- a/projects-dashboard/src/content/project/square_okhttp.md
+++ b/projects-dashboard/src/content/project/square_okhttp.md
@@ -2,7 +2,7 @@
 repo:
   owner: "square"
   name: "okhttp"
-  mainBranch: "master"
+  defaultBranch: "master"
 title: "OkHttp"
 description: "Square’s meticulous HTTP client for the JVM, Android, and GraalVM."
 branding: "square"

--- a/projects-dashboard/src/content/project/square_okio.md
+++ b/projects-dashboard/src/content/project/square_okio.md
@@ -2,7 +2,7 @@
 repo:
   owner: "square"
   name: "okio"
-  mainBranch: "master"
+  defaultBranch: "master"
 title: "okio"
 description: "A modern I/O library for Android, Java, and Kotlin Multiplatform."
 branding: "square"

--- a/projects-dashboard/src/lib/badge.ts
+++ b/projects-dashboard/src/lib/badge.ts
@@ -25,14 +25,14 @@ function getGithubActionsBadge(
   value = "ci.yml",
   label = "ci"
 ): [string, string] {
-  const branch = repo.mainBranch ?? "main";
+  const branch = repo.defaultBranch ?? "main";
   const badgeSrc = `https://img.shields.io/github/actions/workflow/status/${repo.owner}/${repo.name}/${value}?style=flat-square&branch=${branch}&logo=github&label=${label}&logoColor=FFFFFF`;
   const href = `https://github.com/${repo.owner}/${repo.name}/actions/workflows/${value}`;
   return [badgeSrc, href];
 }
 
 function getGithubLicenseBadge(repo: Repo): [string, string] {
-  const branch = repo.mainBranch ?? "main";
+  const branch = repo.defaultBranch ?? "main";
   const badgeSrc = `https://img.shields.io/github/license/${repo.owner}/${repo.name}?style=flat-square&color=4c1&label=license`;
   const href = `https://github.com/${repo.owner}/${repo.name}/blob/${branch}/LICENSE`;
   return [badgeSrc, href];
@@ -60,7 +60,7 @@ function getOssfBadge(repo: Repo): [string, string] {
 }
 
 function getCodecovBadge(repo: Repo, token?: string): [string, string] {
-  const branch = repo.mainBranch ?? "main";
+  const branch = repo.defaultBranch ?? "main";
   const badgeSrc = `https://img.shields.io/codecov/c/gh/${repo.owner}/${repo.name}/${branch}?label=codecov&style=flat-square&token=${token}`;
   const href = `https://codecov.io/github/${repo.owner}/${repo.name}`;
   return [badgeSrc, href];
@@ -119,7 +119,7 @@ function getReferenceDocsBadge(value?: string): [string, string] {
 }
 
 function getCodeOfConductBadge(repo: Repo, value?: string): [string, string] {
-  const branch = repo.mainBranch ?? "main";
+  const branch = repo.defaultBranch ?? "main";
   const badgeSrc = `https://img.shields.io/badge/Code of Conduct-blue?style=flat-square`;
   const href = `https://github.com/${repo.owner}/${repo.name}/blob/${branch}/${value}`;
   return [badgeSrc, href];
@@ -129,7 +129,7 @@ function getContributionGuidelinesBadge(
   repo: Repo,
   value?: string
 ): [string, string] {
-  const branch = repo.mainBranch ?? "main";
+  const branch = repo.defaultBranch ?? "main";
   const badgeSrc = `https://img.shields.io/badge/Contribution Guidelines-orange?style=flat-square`;
   const href = `https://github.com/${repo.owner}/${repo.name}/blob/${branch}/${value}`;
   return [badgeSrc, href];
@@ -189,7 +189,7 @@ function getGithubRepoBadge(repo: Repo): [string, string] {
   const badgeColor = "gray";
   const badgeSrc = `https://img.shields.io/badge/-${badgeValue}-${badgeColor}?style=flat-square&logo=github`;
 
-  const branch = repo.mainBranch ?? "main";
+  const branch = repo.defaultBranch ?? "main";
   const subPathUrlSuffix = repo.subPath ? `/tree/${branch}/${repo.subPath}` : "";
   const href = `https://github.com/${repo.owner}/${repo.name}${subPathUrlSuffix}`;
 


### PR DESCRIPTION
Everything else calls it default branch.

GitHub settings for each repo:

![Screenshot 2025-01-24 at 9 59 51 AM](https://github.com/user-attachments/assets/40e1b5fd-ff6c-41b7-b162-60db6c3ef375)

[official git docs](https://git-scm.com/book/ms/v2/Getting-Started-First-Time-Git-Setup) (scroll to "Your default branch name"):

![Screenshot 2025-01-24 at 10 00 46 AM](https://github.com/user-attachments/assets/4af05036-7be0-4dc2-aa3a-5f44f75e6d61)
