### PR TITLE
feat: Introduce Block OSPO Releaser

### DIFF
--- a/actions/releaser-linter/action.yml
+++ b/actions/releaser-linter/action.yml
@@ -1,0 +1,15 @@
+name: "Releaser Linter"
+description: "Checks PR titles for semantic correctness"
+
+inputs:
+  github-token:
+    description: "GitHub token for authentication"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Semantic PR Title Lint
+      uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/actions/releaser/README.md
+++ b/actions/releaser/README.md
@@ -1,0 +1,184 @@
+# Block OSPO Releaser
+
+Quick and easy GitHub Action to automate secure releases with versioning and changelog generation.
+
+## Usage
+
+**1. Simply add the following release workflow to your repo:**
+
+```yaml
+# .github/workflows/release.yml
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: # for manual publishing retries
+    inputs:
+      retry-publish:
+        description: "Retry publishing"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+  issues: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: block/ospo/actions/releaser@main
+        with:
+          release-type: node
+          node-version: 20
+          npm-token: ${{ secrets.NPM_TOKEN }}
+          package-manager: yarn
+          prepare-cmds: |
+            yarn install --frozen-lockfile
+```
+
+**2. Allow Workflows to Create Pull Requests**
+
+Go to the repo settings > Actions > General > Workflow permissions > and check `Allow GitHub Actions to create and approve pull requests`.
+
+Then, start merging PRs (with titles respecting [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)) and Releaser will take care of the rest.
+
+### How does it work?
+
+Releaser will be watching for relevant commit pushes to the repo default branch. Then it will automatically generate changelog updates and bump the target version respecting SemVer in a temporary Release PR.
+
+This Release PR will be accumulating and grouping the next merged PRs until you are ready to publish, by simply merging it.
+
+Once the Release PR is merged it will publish the release to the GitHub Releases page and will publish the package to the corresponding registry (npm, rubygems, maven, etc).
+
+### Why a release PR vs a direct on-demand publishing workflow?
+
+A release PR allows maintainers to review the changes, generate and test the release candidate, and ensure the release is ready to be published.
+
+It includes **reviewing the exact version** that will be published and **preview the generated changelogs**.
+
+Historically, maintainers also like to implement release approval workflows. That's exactly what you get out-of-the-box when adopting Release PRs.
+
+Also, it's a best practice to avoid bypassing branch protection rules when bumping version number on files and auto-generated changelogs during the CI release process.
+
+### Why Conventional Commits?
+
+When working in the open we need to follow conventions to make sure consumers are well informed about changes and that we are not breaking their services. [Semantic Versioning](https://semver.org/) and Changelogs are the well established industry standard way to do so.
+
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) allow us to automate SemVer bumps and Changelogs generation.
+
+## Support
+
+### Installing on existing repos with prior releases
+
+Releaser works with GitHub releases. The only thing you need is to tag your last release with the last semver tag before installing the action above:
+
+```sh
+git tag -a v1.2.3 -m "v1.2.3"
+git push origin v1.2.3
+```
+
+Then, start merging PRs respecting Conventional Commits in its title and Releaser will take care of the rest:
+
+```sh
+merged PR title: "fix: squash bug"
+# -> Opens a Release PR with patch bump: v1.2.4
+
+merged PR title: "feat: add new feature"
+# -> Opens a Release PR with minor bump: v1.3.0
+
+merged PR title: "feat!: super new improved flow"
+# -> Opens a Release PR with major bump: v2.0.0
+```
+
+_Note: It also works with direct commits pushed to the default branch, but you should not be doing that._
+
+### Troubleshooting
+
+If you are facing any issues, please ping us in our Discord [#ospo](https://discord.com/channels/1287729918100246654/1339722383468007465) channel. You can tag us by using @ospo on your message!
+
+#### 1. My publish failed, what do I do?
+
+If for some reason the registry publishing step fails even though the release was created, you can manually trigger the publish step by re-running the workflow with the `retry-publish` input set to `true`.
+
+#### 2. I need to adjust or improve the message of a previous PR
+
+You can follow the steps below to fix it:
+
+1. Edit the body of the already merged PR inserting the following block:
+
+```
+BEGIN_COMMIT_OVERRIDE
+fix(utils): include forgotten XYZ change
+
+Detailed description of the changes.
+END_COMMIT_OVERRIDE
+```
+
+2. Run the Release workflow manually (no need to check the `retry-publish` input).
+
+_We highly discourage against rewriting the commit because it breaks the git history, and could also break other tools watching the repo, aside from auditing._
+
+#### 3. My merged PR is not being picked up in the Release PR
+
+It happens if the PR merged does not follow the conventional commit message format.
+
+You can follow the same steps of the above issue #2. Just edit the body of the already merged PR and re-run the Release workflow.
+
+To prevent it from happening, you have a few options:
+
+**1. Add a new workflow with the block releaser linter action**
+
+```yaml
+name: "Release Linter PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: block/ospo/actions/releaser-linter@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+This will fail the PR if the title does not follow the conventional commit message format.
+
+This is not guaranteed to work because the merger can still edit the message before merging. (In which case just follow the steps of issue #2, if a mistaken is made).
+
+You should check the GitHub config of the repo to ensure it's always picking the PR title automatically upon clicking the merge button.
+
+**To do that, go to:** github.com/(block-org)/(repo)/settings > scroll down to Pull Requests > Default commit message > and set it to `PR title`.
+
+**2. Add Pre-Commit Hooks or IDE Plugins**
+
+You can add commit linters using hooks locally to fail fast, although **the CI check above is recommended as the authoritative guard‑rail**. Check below a few popular examples:
+
+- **Git Hooks:**
+  - [Husky + commitlint](https://commitlint.js.org/guides/local-setup)
+  - [commitizen auto check](https://commitizen-tools.github.io/commitizen/tutorials/auto_check/)
+- **IDE Plugins:**
+  - [VSCode Conventional Commits extension](https://marketplace.visualstudio.com/items?itemName=vivaxy.vscode-conventional-commits)
+  - [IntelliJ IDEA Conventional Commit plugin](https://plugins.jetbrains.com/plugin/13389-conventional-commit)
+- You can find more here: [Tooling for Conventional Commits](https://www.conventionalcommits.org/en/about/#tooling-for-conventional-commits)
+
+### Supported Release Registries
+
+- npm
+- ruby gems (coming soon)
+
+The action is a thin wrapper around the amazing [release-please](https://github.com/googleapis/release-please) tool. Feel free to dig into their docs if you need more advanced controls and customization in your release. Also, we welcome PRs!

--- a/actions/releaser/action.yml
+++ b/actions/releaser/action.yml
@@ -1,0 +1,153 @@
+name: "Releaser"
+description: "Standardized release process with support from Block OSPO"
+
+inputs:
+  release-type:
+    description: "Release type"
+    required: true
+  node-version:
+    description: "Node version"
+    required: false
+  npm-token:
+    description: "NPM token"
+    required: false
+  prepare-cmds:
+    description: "Publish build preparation commands (ie. `npm ci && npm run test && npm run build`)"
+    required: false
+  package-manager:
+    description: "Package manager (ie. npm, yarn, pnpm, maven, gradle, etc.)"
+    required: false
+  retry-publish:
+    description: "Retry publishing"
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      name: "Validate Context"
+      with:
+        release-type: ${{ inputs.release-type }}
+        node-version: ${{ inputs.node-version }}
+        npm-token: ${{ inputs.npm-token }}
+        package-manager: ${{ inputs.package-manager }}
+        script: |
+          // Reject non-default branches
+          const defaultBranch   = context.payload.repository.default_branch;
+          const isDefaultBranch = context.ref === `refs/heads/${defaultBranch}`;
+          if (!isDefaultBranch) {
+            core.setFailed(`Refusing to publish from non-default branch ${context.ref}`);
+            return;
+          }
+
+          // Allow only default branch pushes or manual runs
+          if (!context.eventName.startsWith('push') && !context.eventName.startsWith('workflow_dispatch')) {
+            core.setFailed(`Refusing to publish for event ${context.eventName}`);
+            return;
+          }
+
+          const releaseType = core.getInput('release-type');
+          if (releaseType === 'node') {
+            const nodeVersion = core.getInput('node-version');
+            const npmToken = core.getInput('npm-token');
+            const packageManager = core.getInput('package-manager');
+            const idToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+            if (!nodeVersion) {
+              core.setFailed("Error: node-version is required when release-type is 'node'");
+              return;
+            }
+            if (!npmToken) {
+              core.setFailed("Error: npm-token is required when release-type is 'node'");
+              return;
+            }
+            if (!packageManager) {
+              core.setFailed("Error: package-manager is required when release-type is 'node'");
+              return;
+            }
+            if (!['npm', 'yarn', 'pnpm'].includes(packageManager)) {
+              core.setFailed("Error: package-manager must be 'npm', 'yarn', or 'pnpm' when release-type is 'node'");
+              return;
+            }
+            if (!idToken) {
+              core.setFailed("Error: permission id-token: write is required to generate provenance for npm");
+              return;
+            }
+          } else {
+            core.setFailed(`Error: unsupported release-type: ${releaseType}`);
+            return;
+          }
+
+          core.info(`✔ Context Guard passed by ${context.actor} on ${context.ref}`);
+
+    - if: ${{ inputs.retry-publish == '' || inputs.retry-publish == 'false' }}
+      uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
+      id: release
+      with:
+        release-type: ${{ inputs.release-type }}
+
+    - shell: bash
+      run: |
+        echo 'Release Debug Outputs:\n${{ toJSON(steps.release.outputs) }}'
+
+    - id: check-release
+      if: ${{ inputs.retry-publish || steps.release.outputs.release_created }}
+      shell: bash
+      run: echo "::set-output name=publish::true"
+
+    - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      if: ${{ steps.check-release.outputs.publish }}
+      name: "Validate caller to publishing"
+      with:
+        script: |
+          // Actor must be admin
+          const {data} = await github.rest.repos.getCollaboratorPermissionLevel({
+            owner: context.repo.owner,
+            repo:  context.repo.repo,
+            username: context.actor
+          });
+          if (!['admin','maintain'].includes(data.permission)) {
+            core.setFailed(
+              `User ${context.actor} has "${data.permission}" permission; ` +
+              `must be admin or maintainer`
+            );
+            return;
+          }
+
+          core.info(`✔ Publishing Guard passed by ${context.actor} on ${context.ref}`);
+
+    - if: ${{ steps.check-release.outputs.publish }}
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - if: ${{ steps.check-release.outputs.publish && inputs.release-type == 'node' }}
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      with:
+        node-version: ${{ inputs.node-version }}
+        registry-url: "https://registry.npmjs.org"
+
+    - if: ${{ steps.check-release.outputs.publish && inputs.prepare-cmds != '' }}
+      shell: bash
+      run: ${{ inputs.prepare-cmds }}
+
+    - if: ${{ steps.check-release.outputs.publish && inputs.release-type == 'node' }}
+      shell: bash
+      env:
+        PACKAGE_MANAGER: ${{ inputs.package-manager }}
+        NODE_AUTH_TOKEN: ${{ inputs.npm-token }}
+      run: |
+        echo "Publishing with $PACKAGE_MANAGER"
+
+        if [ "$PACKAGE_MANAGER" == "yarn" ]; then
+          # provenance is not supported for yarn < 4.9.0
+          # workaround: https://github.com/yarnpkg/berry/issues/5430#issuecomment-1768499845
+          YARN_VERSION=$(yarn --version)
+          YARN_VERSION_MAJOR=$(echo "$YARN_VERSION" | cut -d. -f1)
+          YARN_VERSION_MINOR=$(echo "$YARN_VERSION" | cut -d. -f2)
+          if [ "$YARN_VERSION_MAJOR" -lt 4 ] || [ "$YARN_VERSION_MAJOR" -eq 4 -a "$YARN_VERSION_MINOR" -lt 9 ]; then
+            yarn pack -f package.tgz
+            npm publish package.tgz --access public --provenance
+          else
+            yarn publish --access public --provenance
+          fi
+        else
+          $PACKAGE_MANAGER publish --access public --provenance
+        fi


### PR DESCRIPTION
This pull request introduces two new GitHub Actions: `Releaser` and `Releaser Linter`, along with comprehensive documentation for them. These actions aim to standardize release processes, enforce semantic versioning, and ensure PR titles follow Conventional Commits. The changes include defining the action configurations, adding validation logic, and providing detailed usage instructions.

### New GitHub Actions

#### `Releaser` Action:
* Added a composite GitHub Action (`actions/releaser/action.yml`) to automate secure releases with support for semantic versioning, changelog generation, and registry publishing. It includes validation for inputs like `release-type`, `node-version`, and `npm-token`, and supports Node.js releases with `npm`, `yarn`, or `pnpm`.
* Integrated safeguards to ensure releases are only triggered from the default branch and by authorized users (admin or maintainer permissions).

#### `Releaser Linter` Action:
* Added a composite GitHub Action (`actions/releaser-linter/action.yml`) to validate PR titles against the Conventional Commits standard, ensuring semantic correctness.

### Documentation Updates

* Created a detailed `README.md` for the `Releaser` action, explaining its purpose, setup, usage, and troubleshooting steps. It emphasizes the importance of Conventional Commits and provides examples of how to integrate the action into workflows.